### PR TITLE
On Darwin/OSX the stat "format" option is `-f` instead of `-c`

### DIFF
--- a/_example/hello-world/Makefile
+++ b/_example/hello-world/Makefile
@@ -1,12 +1,18 @@
 # System build
 
+ifeq ($(shell uname),Darwin)
+    FORMAT=-f
+else
+    FORMAT=-c
+endif
+
 build:
 	go build -buildmode=c-shared -ldflags="-w -s" -o handler.so
-	chown `stat -c "%u:%g" .` handler.so
+	chown `stat $(FORMAT) "%u:%g" .` handler.so
 
 pack:
 	zip handler.zip handler.so
-	chown `stat -c "%u:%g" .` handler.zip
+	chown `stat $(FORMAT)-f "%u:%g" .` handler.zip
 
 # Docker build
 


### PR DESCRIPTION
Added a check for the OS and selection of the appropriate option.
